### PR TITLE
Fix "Load Palette…" option

### DIFF
--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -184,7 +184,7 @@ function loadPalette(context) {
 	var app = NSApp.delegate();
 	var doc = context.document;
 	var version = context.plugin.version().UTF8String();
-	var fileTypes = [NSArray arrayWithObjects:@"sketchpalette",nil];
+	var fileTypes = ["sketchpalette"];
 		
 	// Open file picker to choose palette file
 	var open = NSOpenPanel.openPanel();


### PR DESCRIPTION
Works around ccgus/CocoaScript#48, which was preventing the Open panel from appearing on macOS High Sierra 10.13 when selecting the "Load Palette…" option. Prior to this commit, the following error is logged to the Console app when attempting to load a palette:

> ObjC method arrayWithObjects: requires 1 argument, but JavaScript passed 2 arguments

Tangentially, since the same array values are used [here](https://github.com/andrewfiorillo/sketch-palettes/blob/ea6cf1b1f764263884f5dd74250b0d973bb97902/Sketch%20Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js#L100), perhaps a `const ALLOWED_FILE_TYPES = ["sketchpalette"]` would be more ideal.

Anyway, thanks for this plugin. I use it whenever I design in Sketch.