### PR TITLE
update instructions to use official documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Sketch plugin for exporting and importing fill presets. It supports colors, gr
 
 # Installation
 
-Move the Sketch Palettes plugin into your Plugins folder or double-click the .sketchplugin file.
+Refer to the official sketch plugin installation [documentation](https://developer.sketchapp.com/guides/installing-plugins/#installing-plugins)
 
 # Usage
 


### PR DESCRIPTION
This isn't a big deal, but I spent 15mins because I read the readme instructions wrong.

I had read it as "Move the Sketch Palettes plugin into your Plugins folder ***AND*** double-click the .sketchplugin file." Performing both actions causes some very strange results and the plugin never gets installed correctly.

Mostly this just fixes people make dumb mistakes like I did, but by referring to the official documentation you can take advantage of the core team's resources.

Feel free to close if you don't find it valuable.