### PR TITLE
Fix Sketch Palettes for Sketch 53

### DIFF
--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -48,11 +48,11 @@ function savePalette(context) {
 			var assets = app.globalAssets();
 		}
 
-		var showColors = (assets.colors().length > 0 ? true : false);
+		var showColors = (assets.colorAssets().length > 0 ? true : false);
 		checkboxColors.setState(showColors ? NSOnState : NSOffState);
 		checkboxColors.setEnabled(showColors);
 
-		var showGradients = (assets.gradients().length > 0 ? true : false);
+		var showGradients = (assets.gradientAssets().length > 0 ? true : false);
 		checkboxGradients.setState(showGradients ? NSOnState : NSOffState);
 		checkboxGradients.setEnabled(showGradients);
 
@@ -84,12 +84,12 @@ function savePalette(context) {
 		var assets = app.globalAssets();
 	}
 
-	var colors = checkboxColors.state() ? assets.colors() : [];
-	var gradients = checkboxGradients.state() ? assets.gradients() : [];
+	var colorAssets = checkboxColors.state() ? assets.colorAssets() : [];
+	var gradientAssets = checkboxGradients.state() ? assets.gradientAssets() : [];
 	var images = checkboxImages.state() ? assets.images() : [];
 
 	// Check to make sure there are presets available
-	if (colors.length <= 0 && images.length <= 0 && gradients.length <= 0) {
+	if (colorAssets.length <= 0 && images.length <= 0 && gradientAssets.length <= 0) {
 		NSApp.displayDialog("No presets available!");
 		return;
 	}
@@ -108,12 +108,12 @@ function savePalette(context) {
 		var colorPalette = [], gradientPalette = [], imagePalette = [];
 
 		// Colors
-		for (var i = 0; i < colors.length; i++) {
+		for (var i = 0; i < colorAssets.length; i++) {
 			colorPalette.push({
-				red: colors[i].red(),
-				green: colors[i].green(),
-				blue: colors[i].blue(),
-				alpha: colors[i].alpha()
+				red: colorAssets[i].color().red(),
+				green: colorAssets[i].color().green(),
+				blue: colorAssets[i].color().blue(),
+				alpha: colorAssets[i].color().alpha()
 			});
 		}
 
@@ -126,30 +126,30 @@ function savePalette(context) {
 		}
 
 		// Gradients
-		for (var i = 0; i < gradients.length; i++) {
+		for (var i = 0; i < gradientAssets.length; i++) {
 			var gradient_stops = [];
-			for (var j = 0; j < gradients[i].stops().length; j++) {
+			for (var j = 0; j < gradientAssets[i].gradient().stops().length; j++) {
 				stop_color = {
 					_class: "color",
-					red: gradients[i].stops()[j].color().red(),
-					green: gradients[i].stops()[j].color().green(),
-					blue: gradients[i].stops()[j].color().blue(),
-					alpha: gradients[i].stops()[j].color().alpha()
+					red: gradientAssets[i].gradient().stops()[j].color().red(),
+					green: gradientAssets[i].gradient().stops()[j].color().green(),
+					blue: gradientAssets[i].gradient().stops()[j].color().blue(),
+					alpha: gradientAssets[i].gradient().stops()[j].color().alpha()
 				};
 				gradient_stops.push({
 					_class: "gradientStop",
 					color: stop_color,
-					position: gradients[i].stops()[j].position()
+					position: gradientAssets[i].gradient().stops()[j].position()
 				});
 			}
 
 			gradientPalette.push({
 				_class: "gradient",
-				elipseLength: gradients[i].elipseLength(),
-				from: "{" + gradients[i].from().x + "," + gradients[i].from().y + "}",
-				to: "{" + gradients[i].to().x + "," + gradients[i].to().y + "}",
+				elipseLength: gradientAssets[i].gradient().elipseLength(),
+				from: "{" + gradientAssets[i].gradient().from().x + "," + gradientAssets[i].gradient().from().y + "}",
+				to: "{" + gradientAssets[i].gradient().to().x + "," + gradientAssets[i].gradient().to().y + "}",
 				stops: gradient_stops,
-				gradientType: gradients[i].gradientType()
+				gradientType: gradientAssets[i].gradient().gradientType()
 				// shouldSmoothenOpacity: gradients[i].shouldSmoothenOpacity() ? true : false
 			});
 		}

--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -81,7 +81,7 @@ function savePalette(context) {
 	if (selectSource.indexOfSelectedItem() == 0) {
 		var assets = doc.documentData().assets();
 	} else if (selectSource.indexOfSelectedItem() == 1) {
-		MSPersistentAssetCollection.sharedGlobalAssets();
+		var assets = MSPersistentAssetCollection.sharedGlobalAssets();
 	}
 
 	var colorAssets = checkboxColors.state() ? assets.colorAssets() : [];

--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -232,7 +232,7 @@ function loadPalette(context) {
 					colorPalette[i].blue,
 					colorPalette[i].alpha
 				);
-				colorAssets.push(MSColorAsset.alloc().initWithAsset_name(mscolor, ''));
+				colorAssets.push(MSColorAsset.alloc().initWithAsset_name(mscolor, null));
 			}
 		}
 

--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -8,20 +8,20 @@
 
 
 function savePalette(context) {
-	
+
 	var doc = context.document;
 	var app = NSApp.delegate();
 	var version = context.plugin.version().UTF8String();
-	
+
 	// Create dialog
 	var dialog = NSAlert.alloc().init();
 	dialog.setMessageText("Save Palette");
 	dialog.addButtonWithTitle("Save");
 	dialog.addButtonWithTitle("Cancel");
-	
+
 	// Create custom view and fields
 	var customView = NSView.alloc().initWithFrame(NSMakeRect(0, 0, 200, 180));
-	
+
 	var labelSource = createLabel(NSMakeRect(0, 150, 200, 25), 12, false, 'Source:');
 	customView.addSubview(labelSource);
 
@@ -30,13 +30,13 @@ function savePalette(context) {
 
 	var labelFillTypes = createLabel(NSMakeRect(0, 83, 200, 25), 12, false, 'Fill Types:');
 	customView.addSubview(labelFillTypes);
-	
+
 	var checkboxColors = createCheckbox(NSMakeRect(0, 60, 200, 25), "Flat Colors", "colors", true, true);
 	customView.addSubview(checkboxColors);
-	
+
 	var checkboxGradients = createCheckbox(NSMakeRect(0, 37, 200, 25), "Gradients", "gradients", true, true);
 	customView.addSubview(checkboxGradients);
-	
+
 	var checkboxImages = createCheckbox(NSMakeRect(0, 14, 200, 25), "Pattern Fills", "images", true, true);
 	customView.addSubview(checkboxImages);
 
@@ -47,11 +47,11 @@ function savePalette(context) {
 		} else if (selectSource.indexOfSelectedItem() == 1) {
 			var assets = app.globalAssets();
 		}
-		
+
 		var showColors = (assets.colors().length > 0 ? true : false);
 		checkboxColors.setState(showColors ? NSOnState : NSOffState);
 		checkboxColors.setEnabled(showColors);
-		
+
 		var showGradients = (assets.gradients().length > 0 ? true : false);
 		checkboxGradients.setState(showGradients ? NSOnState : NSOffState);
 		checkboxGradients.setEnabled(showGradients);
@@ -60,71 +60,71 @@ function savePalette(context) {
 		checkboxImages.setState(showImages ? NSOnState : NSOffState);
 		checkboxImages.setEnabled(showImages);
 	}
-	
+
 	// set initial chekcbox states
 	setCheckboxStates(selectSource);
-	
+
 	// Listen for select box change event
 	selectSource.setCOSJSTargetFunction(function(sender) {
 		setCheckboxStates(selectSource)
 	});
-	
+
 	// Add custom view to dialog
 	dialog.setAccessoryView(customView);
-	
+
 	// Open dialog and exit if user selects Cancel
 	if (dialog.runModal() != NSAlertFirstButtonReturn) {
 		return;
 	}
-	
+
 	// Get Presets from selected section
 	if (selectSource.indexOfSelectedItem() == 0) {
 		var assets = doc.documentData().assets();
 	} else if (selectSource.indexOfSelectedItem() == 1) {
 		var assets = app.globalAssets();
 	}
-	
+
 	var colors = checkboxColors.state() ? assets.colors() : [];
 	var gradients = checkboxGradients.state() ? assets.gradients() : [];
 	var images = checkboxImages.state() ? assets.images() : [];
-	
+
 	// Check to make sure there are presets available
 	if (colors.length <= 0 && images.length <= 0 && gradients.length <= 0) {
 		NSApp.displayDialog("No presets available!");
 		return;
 	}
-	
+
 	// Create save dialog and set properties
 	var save = NSSavePanel.savePanel();
 	save.setNameFieldStringValue("untitled.sketchpalette");
 	save.setAllowedFileTypes(["sketchpalette"]);
 	save.setAllowsOtherFileTypes(false);
 	save.setExtensionHidden(false);
-		
+
 	// Open save dialog and run if Save was clicked
 	if (save.runModal()) {
-		
+
 		// Build palettes
 		var colorPalette = [], gradientPalette = [], imagePalette = [];
-		
-		// Colors	
+
+		// Colors
 		for (var i = 0; i < colors.length; i++) {
 			colorPalette.push({
 				red: colors[i].red(),
 				green: colors[i].green(),
 				blue: colors[i].blue(),
-				alpha: colors[i].alpha()	
+				alpha: colors[i].alpha()
 			});
 		}
-		
+
 		// Pattern fills
-		for (var i = 0; i < images.length; i++) {	
+		for (var i = 0; i < images.length; i++) {
 			var data = images[i].data()
 			var nsdata = NSData.dataWithData(data);
 			var base64Color = nsdata.base64EncodedStringWithOptions(0).UTF8String();
 			imagePalette.push({data: base64Color});
 		}
-		
+
 		// Gradients
 		for (var i = 0; i < gradients.length; i++) {
 			var gradient_stops = [];
@@ -142,7 +142,7 @@ function savePalette(context) {
 					position: gradients[i].stops()[j].position()
 				});
 			}
-			
+
 			gradientPalette.push({
 				_class: "gradient",
 				elipseLength: gradients[i].elipseLength(),
@@ -153,9 +153,9 @@ function savePalette(context) {
 				// shouldSmoothenOpacity: gradients[i].shouldSmoothenOpacity() ? true : false
 			});
 		}
-		
+
 		// Assemble file contents
-		
+
 		var fileData = {
 			"compatibleVersion": "2.0", // min plugin version to load palette
 			"pluginVersion": version, //  plugin version used to save palette
@@ -163,12 +163,12 @@ function savePalette(context) {
 			"gradients": gradientPalette,
 			"images":  imagePalette
 		};
-		
+
 		// Write file to chosen file path
-		
+
 		var filePath = save.URL().path();
 		var file = NSString.stringWithString(JSON.stringify(fileData));
-		
+
 		file.writeToFile_atomically_encoding_error(filePath, true, NSUTF8StringEncoding, null);
 
 	}
@@ -181,12 +181,12 @@ function savePalette(context) {
 
 
 function loadPalette(context) {
-	
+
 	var app = NSApp.delegate();
 	var doc = context.document;
 	var version = context.plugin.version().UTF8String();
 	var fileTypes = ["sketchpalette"];
-		
+
 	// Open file picker to choose palette file
 	var open = NSOpenPanel.openPanel();
 	open.setAllowedFileTypes(fileTypes);
@@ -196,25 +196,25 @@ function loadPalette(context) {
 	open.setTitle("Choose a file");
 	open.setPrompt("Choose");
 	open.runModal();
-	
+
 	// Read contents of file into NSString, then to JSON
 	var filePath = open.URLs().firstObject().path();
 	var fileContents = NSString.stringWithContentsOfFile(filePath);
 	var paletteContents = JSON.parse(fileContents.toString());
 	var compatibleVersion = paletteContents.compatibleVersion;
-	
+
 	// Check for presets in file, else set to empty array
 	var colorPalette = paletteContents.colors ? paletteContents.colors : [];
 	var gradientPalette = paletteContents.gradients ? paletteContents.gradients : [];
 	var imagePalette = paletteContents.images ? paletteContents.images : [];
-	var colors = [], gradients = [], images = [];
-	
+	var colorAssets = [], gradientAssets = [], images = [];
+
 	// Check if plugin is out of date and incompatible with a newer palette version
 	if (compatibleVersion && compatibleVersion > version) {
 		NSApp.displayDialog("Your plugin is out of date. Please update to the latest version of Sketch Palettes.");
 		return;
 	}
-	
+
 	// Check for older hex code palette version
 	if (!compatibleVersion || compatibleVersion < 1.4) {
 		// Convert hex colors to MSColors
@@ -222,19 +222,20 @@ function loadPalette(context) {
 			colors.push(MSImmutableColor.colorWithSVGString(colorPalette[i]).newMutableCounterpart());
 		}
 	} else {
-		
+
 		// Colors Fills: convert rgba colors to MSColors
 		if (colorPalette.length > 0) {
 			for (var i = 0; i < colorPalette.length; i++) {
-				colors.push(MSColor.colorWithRed_green_blue_alpha(
+				var mscolor = MSColor.colorWithRed_green_blue_alpha(
 					colorPalette[i].red,
 					colorPalette[i].green,
 					colorPalette[i].blue,
 					colorPalette[i].alpha
-				));	
+				);
+				colorAssets.push(MSColorAsset.alloc().initWithAsset_name(mscolor, ''));
 			}
 		}
-		
+
 		// Pattern Fills: convert base64 strings to MSImageData objects
 		if (imagePalette.length > 0) {
 			for (var i = 0; i < imagePalette.length; i++) {
@@ -242,14 +243,14 @@ function loadPalette(context) {
 				var nsimage = NSImage.alloc().initWithData(nsdata);
 				// var msimage = MSImageData.alloc().initWithImageConvertingColorSpace(nsimage);
 				var msimage = MSImageData.alloc().initWithImage(nsimage);
-				images.push(msimage);	
+				images.push(msimage);
 			};
 		}
-		
-		// Gradient Fills: build MSGradientStop and MSGradient objects		
+
+		// Gradient Fills: build MSGradientStop and MSGradient objects
 		if (gradientPalette.length > 0) {
 			for (var i = 0; i < gradientPalette.length; i++) {
-				
+
 				// Create gradient stops
 				var gradient = gradientPalette[i];
 				var stops = [];
@@ -278,22 +279,22 @@ function loadPalette(context) {
 				msgradient.setFrom({ x: fromValue[0], y: fromValue[1] });
 				msgradient.setTo({ x: toValue[0], y: toValue[1] });
 
-				gradients.push(msgradient);
-				
+				gradientAssets.push(MSGradientAsset.alloc().initWithAsset_name(msgradient, ''));
+
 			}
 		}
-		
+
 	}
-	
+
 	// Create dialog
 	var dialog = NSAlert.alloc().init();
 	dialog.setMessageText("Load Palette");
 	dialog.addButtonWithTitle("Load");
 	dialog.addButtonWithTitle("Cancel");
-	
+
 	// Create custom view and fields
 	var customView = NSView.alloc().initWithFrame(NSMakeRect(0, 0, 200, 180));
-	
+
 	var labelSource = createLabel(NSMakeRect(0, 150, 200, 25), 12, false, 'Source:');
 	customView.addSubview(labelSource);
 
@@ -302,40 +303,40 @@ function loadPalette(context) {
 
 	var labelFillTypes = createLabel(NSMakeRect(0, 83, 200, 25), 12, false, 'Fill Types:');
 	customView.addSubview(labelFillTypes);
-	
+
 	var showColors = (colorPalette.length > 0) ? true : false);
 	var checkboxColors = createCheckbox(NSMakeRect(0, 60, 200, 25), "Flat Colors", "colors", showColors, showColors);
 	customView.addSubview(checkboxColors);
-	
+
 	var showGradients = (gradientPalette.length > 0) ? true : false);
 	var checkboxGradients = createCheckbox(NSMakeRect(0, 37, 200, 25), "Gradients", "gradients", showGradients, showGradients);
 	customView.addSubview(checkboxGradients);
-	
+
 	var showImages = (imagePalette.length > 0 ? true : false);
 	var checkboxImages = createCheckbox(NSMakeRect(0, 14, 200, 25), "Pattern Fills", "images", showImages, showImages);
 	customView.addSubview(checkboxImages);
-	
+
 	// Add custom view to dialog
 	dialog.setAccessoryView(customView);
-	
+
 	// Open dialog and exit if user hits cancel.
 	if (dialog.runModal() != NSAlertFirstButtonReturn) return;
-	
+
 	// Get target picker section
 	if (selectSource.indexOfSelectedItem() == 0) {
 		var assets = doc.documentData().assets();
 	} else if (selectSource.indexOfSelectedItem() == 1) {
 		var assets = app.globalAssets();
 	}
-	
+
 	// Append presets
-	if (colors.length > 0) assets.addColors(colors);
+	if (colorAssets.length > 0) assets.addColorAssets(colorAssets);
 	if (images.length > 0) assets.setImages(assets.images().slice().concat(images));
-	if (gradients.length > 0) assets.addGradients(gradients);
-	
+	if (gradientAssets.length > 0) assets.addGradientAssets(gradientAssets);
+
 	doc.inspectorController().closeAnyColorPopover();
 	app.refreshCurrentDocument();
-	
+
 }
 
 
@@ -345,21 +346,21 @@ function loadPalette(context) {
 
 
 function clearPalette(context) {
-	
+
 	var doc = context.document;
 	var selection = context.selection;
 	var app = NSApp.delegate();
 	var version = context.plugin.version().UTF8String();
-	
+
 	// Create dialog
 	var dialog = NSAlert.alloc().init();
 	dialog.setMessageText("Clear Palette");
 	dialog.addButtonWithTitle("Clear");
 	dialog.addButtonWithTitle("Cancel");
-	
+
 	// Create view to hold custom fields
 	var customView = NSView.alloc().initWithFrame(NSMakeRect(0, 0, 200, 180));
-	
+
 	var labelSource = createLabel(NSMakeRect(0, 150, 200, 25), 12, false, 'Source:');
 	customView.addSubview(labelSource);
 
@@ -368,34 +369,34 @@ function clearPalette(context) {
 
 	var labelFillTypes = createLabel(NSMakeRect(0, 83, 200, 25), 12, false, 'Fill Types:');
 	customView.addSubview(labelFillTypes);
-	
+
 	var checkboxColors = createCheckbox(NSMakeRect(0, 60, 200, 25), "Flat Colors", "colors", true, true);
 	customView.addSubview(checkboxColors);
-	
+
 	var checkboxGradients = createCheckbox(NSMakeRect(0, 37, 200, 25), "Gradients", "colors", true, true);
 	customView.addSubview(checkboxGradients);
 
 	var checkboxImages = createCheckbox(NSMakeRect(0, 14, 200, 25), "Pattern Fills", "images", true, true);
 	customView.addSubview(checkboxImages);
-	
+
 	// Add custom view to dialog
 	dialog.setAccessoryView(customView);
-	
+
 	// Open dialog and exit if user hits cancel.
 	if (dialog.runModal() != NSAlertFirstButtonReturn) return;
-	
+
 	// Get target picker section
 	if (selectSource.indexOfSelectedItem() == 0) {
 		var assets = doc.documentData().assets();
 	} else if (selectSource.indexOfSelectedItem() == 1) {
 		var assets = app.globalAssets();
 	}
-	
+
 	// Clear presets in chosen sections
 	if (checkboxColors.state()) assets.setColors([]);
 	if (checkboxImages.state()) assets.setImages([]);
 	if (checkboxGradients.state()) assets.setGradients([]);
-	
+
 	doc.inspectorController().closeAnyColorPopover();
 	app.refreshCurrentDocument();
 

--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -45,7 +45,7 @@ function savePalette(context) {
 		if (selectSource.indexOfSelectedItem() == 0) {
 			var assets = doc.documentData().assets();
 		} else if (selectSource.indexOfSelectedItem() == 1) {
-			var assets = app.globalAssets();
+			var assets = MSPersistentAssetCollection.sharedGlobalAssets();
 		}
 
 		var showColors = (assets.colorAssets().length > 0 ? true : false);
@@ -81,7 +81,7 @@ function savePalette(context) {
 	if (selectSource.indexOfSelectedItem() == 0) {
 		var assets = doc.documentData().assets();
 	} else if (selectSource.indexOfSelectedItem() == 1) {
-		var assets = app.globalAssets();
+		MSPersistentAssetCollection.sharedGlobalAssets();
 	}
 
 	var colorAssets = checkboxColors.state() ? assets.colorAssets() : [];
@@ -326,7 +326,7 @@ function loadPalette(context) {
 	if (selectSource.indexOfSelectedItem() == 0) {
 		var assets = doc.documentData().assets();
 	} else if (selectSource.indexOfSelectedItem() == 1) {
-		var assets = app.globalAssets();
+		var assets = MSPersistentAssetCollection.sharedGlobalAssets();
 	}
 
 	// Append presets
@@ -389,7 +389,7 @@ function clearPalette(context) {
 	if (selectSource.indexOfSelectedItem() == 0) {
 		var assets = doc.documentData().assets();
 	} else if (selectSource.indexOfSelectedItem() == 1) {
-		var assets = app.globalAssets();
+		var assets = MSPersistentAssetCollection.sharedGlobalAssets();
 	}
 
 	// Clear presets in chosen sections

--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -393,9 +393,9 @@ function clearPalette(context) {
 	}
 
 	// Clear presets in chosen sections
-	if (checkboxColors.state()) assets.setColors([]);
+	if (checkboxColors.state()) assets.setColorAssets([]);
 	if (checkboxImages.state()) assets.setImages([]);
-	if (checkboxGradients.state()) assets.setGradients([]);
+	if (checkboxGradients.state()) assets.setGradientAssets([]);
 
 	doc.inspectorController().closeAnyColorPopover();
 	app.refreshCurrentDocument();

--- a/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
+++ b/Sketch Palettes.sketchplugin/Contents/Sketch/sketchPalettes.js
@@ -279,7 +279,7 @@ function loadPalette(context) {
 				msgradient.setFrom({ x: fromValue[0], y: fromValue[1] });
 				msgradient.setTo({ x: toValue[0], y: toValue[1] });
 
-				gradientAssets.push(MSGradientAsset.alloc().initWithAsset_name(msgradient, ''));
+				gradientAssets.push(MSGradientAsset.alloc().initWithAsset_name(msgradient, null));
 
 			}
 		}


### PR DESCRIPTION
#77  – I'm able to load, save and clear palettes again **ONLY** for document colors.
Sketch appears to have removed `app.globalColors`, still figuring out the proper replacement for this.

But at least some if it is working again.

**EDIT** – Global assets/colors is also fixed.